### PR TITLE
#265 fix : "disallow nickname with white-spaces"

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -1,7 +1,6 @@
 import os
 from .utils import (
     email_isvalid,
-    username_isvalid,
 )
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -43,15 +42,11 @@ class UserSerializer(serializers.ModelSerializer):
         )
         read_only_fields = ("id",)
 
+    # TODO: refactor : 아래 email, nickname과 같은 도메인 로직은 model layer로 이동
     def validate_email(self, obj):
         if email_isvalid(obj):
             return obj
         raise serializers.ValidationError('메일 형식이 올바르지 않습니다.')
-
-    def validate_username(self, obj):
-        if username_isvalid(obj):
-            return obj
-        raise serializers.ValidationError('닉네임은 한 글자 이상이어야 합니다.')
 
     def create(self, validated_data):
         #password = validated_data.get("password")

--- a/users/utils.py
+++ b/users/utils.py
@@ -1,22 +1,12 @@
 import re
 
+
 def email_isvalid(value):
     try:
-        validation = re.compile(r'^[a-zA-Z0-9+-_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$')
+        validation = re.compile(
+            r'^[a-zA-Z0-9+-_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$')
         if not re.match(validation, value):
             raise Exception('올바른 메일 형식이 아닙니다.')
         return value
     except Exception as e:
         print('예외가 발생했습니다.', e)
-
-def username_isvalid(value):
-    try:
-        if len(value) > 1:
-            return value
-        raise Exception('닉네임은 2 자리 이상이어야 합니다.')
-    except Exception as e:
-        print('예외가 발생했습니다.', e)
-# def execute(self, sql, params=None):
-# 				# 실행되는 모든 sql을 만드는 sql문과 params를 출력
-#         print(sql, params)
-#         return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)

--- a/users/views/base_view.py
+++ b/users/views/base_view.py
@@ -4,6 +4,7 @@ from functools import partial
 from django.contrib.auth import get_user_model
 from django.db.models import Q
 from django.utils.decorators import method_decorator
+from django.core.exceptions import ValidationError
 from rest_framework import status
 from rest_framework import viewsets
 from rest_framework.response import Response
@@ -139,7 +140,13 @@ class SignupView(SetPartialMixin, CreateAPIView):
     ]
 
     def create(self, request, *args, **kwargs):
-        super().create(request, *args, **kwargs)
+        try:
+            super().create(request, *args, **kwargs)
+        except Exception as e:
+            return Response({
+                'status': 'fail',
+                'message': str(e),
+            }, status=status.HTTP_400_BAD_REQUEST)
         return Response({
             'status': 'Success',
         }, status=status.HTTP_200_OK)
@@ -187,12 +194,18 @@ class MeView(APIView):
                         'code': 400,
                     }, status=status.HTTP_400_BAD_REQUEST)
 
-            serializer.save()
+            try:
+                user = serializer.save()
+            except ValidationError as e:
+                return Response({
+                    'status': 'fail',
+                    'message': str(e),
+                }, status=status.HTTP_400_BAD_REQUEST)
 
             if 'nickname' in serializer.validated_data:  # nickname이 변경되었을 경우
                 return Response({
                     'status': 'success',
-                    'data': {"nickname": serializer.validated_data['nickname']},
+                    'data': {"nickname": user.nickname},
                 }, status=status.HTTP_200_OK)
 
             else:


### PR DESCRIPTION
- 공백이 포함된 닉네임일 경우, 공백 제거 후 닉네임 변경
- User 모델의 nickname에 대한 도메인 지식을 Controller 레이어(View, Serializer)에서 Model 레이어(Model, Model Manager)로 이동
  - User 모델의 clean 함수에 닉네임 검증 로직이 구현됨

Signed-off-by: Sejong Kim <sepaper@naver.com>