### PR TITLE
#298 fix : change place review photo upload path

### DIFF
--- a/places/services.py
+++ b/places/services.py
@@ -112,13 +112,12 @@ class PlaceVisitorReviewPhotoService:
 
     @transaction.atomic
     def create(self, place_review: PlaceVisitorReview, image_files: list[InMemoryUploadedFile]):
-        place_name = PlaceVisitorReview.objects.get(id=place_review.id).place.place_name
         photos = []
 
         for image_file in image_files:
 
             ext = image_file.name.split(".")[-1]
-            file_path = '{}/{}-{}.{}'.format(place_name, place_review.id,
+            file_path = '{}/{}-{}.{}'.format(place_review.id, place_review.id,
                                             str(time.time())+str(uuid.uuid4().hex), ext)
             image = ImageFile(io.BytesIO(image_file.read()), name=file_path)
 


### PR DESCRIPTION
- 파일 경로에 한글명이 포함되어 있는 경우, photo_image_urls와 image_files 간 비교가 불가능해서 사진 업로드 시 오류 발생