### PR TITLE
#350 feat : add Curation permissions and return writer_email

### DIFF
--- a/curations/permissions.py
+++ b/curations/permissions.py
@@ -9,3 +9,12 @@ class IsWriter(BasePermission):
         if hasattr(obj, 'writer'):
             return obj.writer.id == request.user.id
         return True
+
+
+class IsVerifiedOrSdpAdmin(BasePermission):
+    def has_permission(self, request, view):
+        if request.user.is_authenticated:
+            if request.user.is_verified or request.user.is_sdp_admin:
+                return True
+        else:
+            return False

--- a/curations/selectors.py
+++ b/curations/selectors.py
@@ -58,7 +58,8 @@ class CurationSelector:
                 default=Concat(Value(settings.MEDIA_URL),
                                F('photos__image'),
                                output_field=CharField())
-            )
+            ),
+            writer_email=F('writer__email')
         )
 
         return curations
@@ -85,7 +86,8 @@ class CurationSelector:
             ),
             map_image=Concat(Value(settings.MEDIA_URL),
                              F('map_photos__map'),
-                             output_field=CharField())
+                             output_field=CharField()),
+            writer_email=F('writer__email')
         )
 
         return curation
@@ -101,13 +103,14 @@ class CurationSelector:
                                F('photos__image'),
                                output_field=CharField())
             ),
+            writer_email=F('writer__email')
         )
 
         return curations
 
     def admin_curation_list(self):
         curations = Curation.objects.filter(
-            is_released=True, writer__is_sdp_admin=True, is_rep=False).annotate(
+            is_released=True, writer__is_sdp_admin=True).annotate(
             rep_pic=Case(
                 When(
                     photos__image=None,
@@ -117,6 +120,7 @@ class CurationSelector:
                                F('photos__image'),
                                output_field=CharField())
             ),
+            writer_email=F('writer__email')
         )
 
         return curations
@@ -133,6 +137,7 @@ class CurationSelector:
                                F('photos__image'),
                                output_field=CharField())
             ),
+            writer_email=F('writer__email')
         )
 
         return curations
@@ -190,7 +195,8 @@ class CuratedStorySelector:
             nickname=F('writer__nickname'),
             profile_image=Concat(Value(settings.MEDIA_URL),
                                  F('writer__profile_image'),
-                                 output_field=CharField())
+                                 output_field=CharField()),
+            writer_email=F('writer__email')
         )
 
 

--- a/curations/views.py
+++ b/curations/views.py
@@ -25,7 +25,7 @@ class CurationListApi(APIView):
         id = serializers.IntegerField()
         title = serializers.CharField()
         rep_pic = serializers.CharField()
-        writer = serializers.CharField()
+        writer_email = serializers.CharField()
         is_selected = serializers.BooleanField()
 
     @swagger_auto_schema(
@@ -44,7 +44,7 @@ class CurationListApi(APIView):
                         'id': 1,
                         'title': '서울 비건카페 탑5',
                         'rep_pic': 'https://abc.com/1.jpg',
-                        'writer': 'sdptech@gmail.com',
+                        'writer_email': 'sdptech@gmail.com',
                         'is_selected': True,
                     }
                 }
@@ -85,7 +85,7 @@ class RepCurationListApi(APIView):
         id = serializers.IntegerField()
         title = serializers.CharField()
         rep_pic = serializers.CharField()
-        writer = serializers.CharField()
+        writer_email = serializers.CharField()
         is_selected = serializers.BooleanField()
 
     @swagger_auto_schema(
@@ -103,7 +103,7 @@ class RepCurationListApi(APIView):
                         'id': 1,
                         'title': '서울 비건카페 탑5',
                         'rep_pic': 'https://abc.com/1.jpg',
-                        'writer': 'sdptech@gmail.com',
+                        'writer_email': 'sdptech@gmail.com',
                         'is_selected': True,
                     }
                 }
@@ -131,7 +131,7 @@ class AdminCurationListApi(APIView):
         id = serializers.IntegerField()
         title = serializers.CharField()
         rep_pic = serializers.CharField()
-        writer = serializers.CharField()
+        writer_email = serializers.CharField()
         is_selected = serializers.BooleanField()
 
     @swagger_auto_schema(
@@ -149,7 +149,7 @@ class AdminCurationListApi(APIView):
                         'id': 1,
                         'title': '제로웨이스트',
                         'rep_pic': 'https://abc.com/1.jpg',
-                        'writer': 'sdptech@gmail.com',
+                        'writer_email': 'sdptech@gmail.com',
                         'is_selected': True,
                     }
                 }
@@ -177,7 +177,7 @@ class VerifiedUserCurationListApi(APIView):
         id = serializers.IntegerField()
         title = serializers.CharField()
         rep_pic = serializers.CharField()
-        writer = serializers.CharField()
+        writer_email = serializers.CharField()
         is_selected = serializers.BooleanField()
 
     @swagger_auto_schema(
@@ -195,7 +195,7 @@ class VerifiedUserCurationListApi(APIView):
                         'id': 1,
                         'title': '제로웨이스트',
                         'rep_pic': 'https://abc.com/1.jpg',
-                        'writer': 'sdptech@gmail.com',
+                        'writer_email': 'sdptech@gmail.com',
                         'is_selected': True,
                     }
                 }
@@ -224,7 +224,7 @@ class CurationDetailApi(APIView):
         contents = serializers.CharField()
         rep_pic = serializers.CharField()
         like_curation = serializers.BooleanField()
-        writer = serializers.CharField()
+        writer_email = serializers.CharField()
         writer_is_verified = serializers.BooleanField()
         created = serializers.CharField()
         map_image = serializers.CharField()
@@ -244,7 +244,7 @@ class CurationDetailApi(APIView):
                         'contents': '서울 비건카페 5곳을 소개합니다',
                         'rep_pic': 'https://abc.com/1.jpg',
                         'like_curation': True,
-                        'writer': 'sdptech@gmail.com',
+                        'writer_email': 'sdptech@gmail.com',
                         'writer_is_verified': True,
                         'map_image': 'https://abc.com/1.jpg',
                     },
@@ -282,7 +282,7 @@ class CuratedStoryDetailApi(APIView):
         hashtags = serializers.CharField()
         rep_photos = serializers.ListField(required=False)
 
-        writer = serializers.CharField()
+        writer_email = serializers.CharField()
         nickname = serializers.CharField()
         profile_image = serializers.CharField()
         created = serializers.CharField()
@@ -306,7 +306,7 @@ class CuratedStoryDetailApi(APIView):
                         'like_story': True,
                         'hashtags': '#버섯농장 #로컬마켓 #성수동 #비건',
                         'rep_photos':  "['https://abc.com/1.jpg', 'https://abc.com/2.jpg', 'https://abc.com/3.jpg']",
-                        'writer': 'sdp.tech@gmail.com',
+                        'writer_email': 'sdp.tech@gmail.com',
                         'nickname': '스드프',
                         'profile_image': 'https://abc.com/1.jpg',
                         'created': '2022-08-24T14:15:22Z'

--- a/curations/views.py
+++ b/curations/views.py
@@ -11,7 +11,7 @@ from drf_yasg.utils import swagger_auto_schema
 
 from .selectors import CurationSelector, CuratedStoryCoordinatorSelector
 from .services import CurationCoordinatorService, CurationLikeService
-from .permissions import IsWriter
+from .permissions import IsWriter, IsVerifiedOrSdpAdmin
 from curations.models import Curation
 
 
@@ -331,8 +331,7 @@ class CuratedStoryDetailApi(APIView):
 
 
 class CurationCreateApi(APIView):
-    # TODO: admin, verified 사용자만 작성 가능하도록 변경 필요
-    permission_classes = (IsAuthenticated, )
+    permission_classes = (IsVerifiedOrSdpAdmin, )
 
     class CurationCreateInputSerializer(serializers.Serializer):
         title = serializers.CharField()


### PR DESCRIPTION
1. return `writer_email` instead of `writer_id` in CurationList APIs
2. check permission for CurationCreate API