### PR TITLE
#350 fix : list distinct stories in CuratedStoryApi

### DIFF
--- a/curations/selectors.py
+++ b/curations/selectors.py
@@ -158,7 +158,7 @@ class CuratedStoryCoordinatorSelector:
         self.user = user
 
     def detail(self, curation_id: int):
-        story_id_list = Curation.objects.get(id=curation_id).story.all()
+        story_id_list = Curation.objects.distinct().get(id=curation_id).story.all()
         curated_stories_qs = CuratedStorySelector.detail(
             story_id_list=story_id_list, user=self.user)
 


### PR DESCRIPTION
-큐레이션에 속한 스토리들이 중복 나열되는 에러