### PR TITLE
fix: Add Count & Delete Pagination in Total Search

### DIFF
--- a/curations/selectors.py
+++ b/curations/selectors.py
@@ -72,6 +72,8 @@ class CurationSelector:
 
         if order in order_by_time:
             order = order_by_time[order]
+        else:
+            order = 'created'
 
         curations = Curation.objects.distinct().filter(q, is_released=True).annotate(
             rep_pic=Case(

--- a/curations/selectors.py
+++ b/curations/selectors.py
@@ -431,6 +431,17 @@ class TotalSearchSelector:
                          } for s in stories]
 
         #세개의 데이터를 체인으로 연결
-        result = list(chain(curations_data, forests_data, stories_data))
+        result_data = list(chain(curations_data, forests_data, stories_data))
 
+        #모델 유형별 객체 수를 저장
+        curation_count = curations.count()
+        forest_count = forests.count()
+        story_count = stories.count()
+
+        result = {
+            'curation_count': curation_count,
+            'forest_count':forest_count,
+            'story_count': story_count,
+            'result_data': result_data,
+        }
         return result

--- a/curations/urls.py
+++ b/curations/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import CurationLikeApi, RepCurationListApi, AdminCurationListApi, VerifiedUserCurationListApi, CuratedStoryDetailApi, CurationDetailApi, CurationCreateApi, CurationUpdateApi, CurationDeleteApi, CurationListApi
+from .views import CurationLikeApi, RepCurationListApi, AdminCurationListApi, VerifiedUserCurationListApi, CuratedStoryDetailApi, CurationDetailApi, CurationCreateApi, CurationUpdateApi, CurationDeleteApi, CurationListApi, TotalSearchApi
 
 urlpatterns = [
     path('rep_curations/', RepCurationListApi.as_view(), name="rep_curations"),
@@ -19,4 +19,5 @@ urlpatterns = [
          CurationDeleteApi.as_view(), name='curation_delete'),
     path('curation_like/<int:curation_id>/',
          CurationLikeApi.as_view(), name='curation_like'),
+    path('total_search/',TotalSearchApi.as_view(), name="total_search"),
 ]

--- a/curations/views.py
+++ b/curations/views.py
@@ -644,10 +644,6 @@ class CurationLikeApi(APIView):
 class TotalSearchApi(APIView):
     permission_classes=(AllowAny, )
 
-    class Pagination(PageNumberPagination):
-        page_size = 8
-        page_size_query_param = 'page_size'
-
     class TotalSearchFilterSerializer(serializers.Serializer):
         search = serializers.CharField(required=False)
         order = serializers.CharField(required=False)
@@ -670,7 +666,7 @@ class TotalSearchApi(APIView):
         query_serializer=TotalSearchFilterSerializer,
         operation_id='통합 검색 결과 리스트',
         operation_description='''
-            통합 검색 결과를 리스트합니다.</br>
+            통합 검색 결과를 리스트합니다.(각 모델마다 객체의 수 또한 리턴합니다.)</br>
             search(검색어)의 default값은 ''로, 검색어가 없을 시 아무것도 반환되지 않습니다.
             order(정렬)은 latest 또는 oldest로 최신순 정렬 여루블 결정합니다.
             반환되는 정보는</br>
@@ -691,6 +687,7 @@ class TotalSearchApi(APIView):
                 description="OK",
                 examples={
                     "application/json":{
+
                         'id':1,
                         'model': 'Curation',
                         'title': '서울 비건카페',
@@ -722,10 +719,11 @@ class TotalSearchApi(APIView):
             order = filters.get('order', ''),
             user=request.user
         )
-        return get_paginated_response(
-            pagination_class=self.Pagination,
-            serializer_class=self.TotalSearchOutputSerializer,
-            queryset=results,
-            request=request,
-            view=self
-        )
+
+        return Response({
+            'status': 'success',
+            'curation_count':results['curation_count'],
+            'forest_count':results['forest_count'],
+            'story_count':results['story_count'],
+            'data': results['result_data'],
+        }, status= status.HTTP_200_OK)

--- a/curations/views.py
+++ b/curations/views.py
@@ -687,7 +687,7 @@ class TotalSearchApi(APIView):
             10. 유저 좋아요 여부 user_likes
 
             ''',
-        response={
+        responses={
             "200": openapi.Response(
                 description="OK",
                 examples={


### PR DESCRIPTION
통합검색에서
pagination을 제거하고
curation, forest, story에 대한 각각의 객체의 수를 count한 값을 함꼐 리턴합니다.